### PR TITLE
Add os matrix in gh action

### DIFF
--- a/.github/workflows/execute.yaml
+++ b/.github/workflows/execute.yaml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   base:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
- Explicitly run on 20.04 and 22.04